### PR TITLE
add function to evaluate stability of RAS reference points

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-version = "0.1.0"
+version = "0.2.0rc1"
 dependencies = ["pandas"]
 
 [project.optional-dependencies]


### PR DESCRIPTION
* Adds function `hydrostab.ras.refpoints_stability`, which behaves very similarly to `hydrostab.ras.reflines_stability`.
* Bump version number to `0.2.0rc1`